### PR TITLE
Add composer.json file to easy installation in Composer projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ MiniPaviCli.php est la classe pour s'interfacer avec la passerelle.
 
 Plus d'info sur http://www.minipavi.fr
 
-Les scripts de mini-services MiniChat, France24 et SNCF sont fournis à titrre d'exemple.
+Les scripts de mini-services MiniChat, France24 et SNCF sont fournis à titre d'exemple.
 
 # Contenu
 
-- MiniPaviCli.php: Classe pour communiquer avec la psserelle MiniPavi  
+- MiniPaviCli.php: Classe pour communiquer avec la passerelle MiniPavi  
 - README.md: Ce fichier  
 
 - **MiniChat**  
@@ -35,7 +35,7 @@ Les scripts de mini-services MiniChat, France24 et SNCF sont fournis à titrre d
   
 - **France24**  
   - FRANCE24.VDT: Page videotex d'accueil du service  
-  - france24Functions.php: Fonctions utilisée dans le script du service  
+  - france24Functions.php: Fonctions utilisées dans le script du service  
   - index.php: script du service  
 
 - **MiniSncf**  
@@ -46,23 +46,24 @@ Les scripts de mini-services MiniChat, France24 et SNCF sont fournis à titrre d
   
   Remarque: vous devez indiquer une clé pour l'API Sncf dans le fichier MiniAPISncf.php  
   Disponible sur https://numerique.sncf.com/startup/api/
-  
-  
+
 # Pré-requis
 
 Serveur Web + PHP (les scripts ont été testés avec PHP8.2 et 7.3)
 
 # Installation rapide d'un service
-- Copier dans un repertoire accessible les fichiers d'un service +  MiniPaviCli.php
+
+- Copier dans un repertoire accessible les fichiers d'un service + MiniPaviCli.php
 - Modifier le fichier index.php pour que le chemin vers MiniPaviCli.php soit correct
 
 Voilà, terminé.
 
-Si le dossier de votre installation est acessible par exemple via l'url:
+Si le dossier de votre installation est accessible par exemple via l'url:
 http://www.monsite.fr/test/
 
 alors, le service installé est accessible par websocket à l'url:
 ws://go.minipavi.fr:8182/url=http://www.monsite.fr/test/
 
-Vous pouvez utiliser, par exemple, l'emulateur Minitel (de MiEdit) disponible sur www.minipavi.fr pour y accéder
+Vous pouvez utiliser, par exemple, l'émulateur Minitel (de MiEdit) disponible sur www.minipavi.fr pour y accéder.
 
+La librairie est aussi installable via composer: `composer require ludosevilla/minipavi-cli`.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+  "name": "ludosevilla/minipavi-cli",
+  "type": "library",
+  "description": "SDK for MiniPavi, Minitel to HTTP platform",
+  "keywords": ["minitel"],
+  "homepage": "https://www.minipavi.fr/",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Jean-arthur Silve",
+      "email": "contact@minipavi.fr"
+    }
+  ],
+  "require": {
+    "php": ">=7.3"
+  },
+  "autoload": {
+    "psr-4": {
+      "MiniPavi\\": ""
+    }
+  }
+}


### PR DESCRIPTION
Refs: #1

Voici le fichier composer que je propose, il permet PHP 7 et 8, et spécifie la license GPL v2 et plus - je n'étais pas sûr de la version car le README dit `Licence GNU GPL` simplement.

Avoir ce fichier ne suffit pas, il faut maintenant : 

- suivre la procédure sur https://packagist.org/about pour ajouter un package
- suivre la procédure "How to update packages?" sur cette même page
- créer des tag git à chaque nouvelle version

Merci !